### PR TITLE
specified version 1.76 for biopython. Latest working version for pyth…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 pip install pysam --user
-pip install biopython --user
+pip install biopython==1.76 --user
 pip install intervaltree --user
 pip install https://files.pythonhosted.org/packages/cb/bb/2362099ca5d680e39f75a37b2c8f677fc2d3dda94ce51b3738feff58d136/jellyfish-0.6.0.tar.gz#sha256=f5da646c4ff578ff37695915c05eaae938b1218082bfef59f8a7183477681ab0 --user
 pip install numpy --user


### PR DESCRIPTION
Hi Jaque and Serghei, while installing imrep via anaconda2 package manager, the install.sh file did not specify a specific version of biopython that is compatible with python 2.7. I recommend merging this change so that users can install this tool with either python 2 or 3. 

